### PR TITLE
Fix workspace definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-workspace.resolver = "2"
+resolver = "2"
 members = ["scraper", "airbnb"]

--- a/airbnb/src/lib.rs
+++ b/airbnb/src/lib.rs
@@ -1,9 +1,12 @@
+use serde::Serialize;
 use std::error::Error;
 use std::thread;
 use std::time::Duration;
-use thirtyfour::{prelude::{WebDriverError, ElementWaitable}, By, DesiredCapabilities, WebDriver, WebElement};
+use thirtyfour::{
+    prelude::{ElementWaitable, WebDriverError},
+    By, DesiredCapabilities, WebDriver, WebElement,
+};
 use url::Url;
-use serde::Serialize;
 
 pub async fn scrape_airbnb(place: &str) -> Result<(), Box<dyn Error>> {
     let driver = initialize_driver().await?;
@@ -69,7 +72,6 @@ async fn load_next_page(
     next_page_button: WebElement,
     driver: &WebDriver,
 ) -> Result<(), Box<dyn Error>> {
-
     next_page_button.click().await?;
     thread::sleep(Duration::from_secs(2));
 

--- a/airbnb/src/lib.rs
+++ b/airbnb/src/lib.rs
@@ -36,15 +36,15 @@ async fn scrape_all(driver: WebDriver) -> Result<(), Box<dyn Error>> {
 
             match next_page_button.is_clickable().await? {
                 true => {
-                    
+
                     //start extracting data
-                    
+
                     let house_elems = get_house_elements(&driver).await?;
 
                     for house_elem in house_elems {
 
                         let bnb_details = BnbDetails::from(house_elem).await?;
-                        
+
                         wtr.serialize(bnb_details)?;
 
                     }

--- a/scraper/src/main.rs
+++ b/scraper/src/main.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<(),Box<dyn Error>>{
+async fn main() -> Result<(), Box<dyn Error>> {
     airbnb::scrape_airbnb("Rome").await?;
     Ok(())
 }


### PR DESCRIPTION
I'm enjoying looking through `rust-scraping` and wanted to contribute a couple of fixes that were making my life easier.

This PR:
- allows users to run `cargo run` by capitalizing the `c` in `Cargo.toml`
- fixes a warning produced by the `resolver` definition formatting in `Cargo.toml`
- fixes trailing whitespace preventing use of `cargo fmt`
